### PR TITLE
Fix the URL for loading projects from DB in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ QGIS Server can load QGIS projects directly from a postgresql database.
 
 This image is preconfigured to load projects from the database when QGIS Server is called as follows:
 
-    http://localhost:8001/qgis/pg/<schema>/<projectname>
+    http://localhost:8001/ows/pg/<schema>/<projectname>
 
 It will use the `qgisprojects` postgresql service connection, which must be defined in the `pg_service.conf` which is mounted into the `qwc-qgis-server` container.
 


### PR DESCRIPTION
It seems, the URL_PREFIX env var used to be set to `qgis` in the past. This was changed here 
a3169ad3fae79907c246ff7a75ba1923e2f5a3c2, but the README was not updated.
