### PR TITLE
feat: Enhance Dockerfile for OpenShift compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,28 @@ RUN \
     chown $UID /etc/apache2/ports.conf && \
     chown $UID /etc/apache2
 
+# OpenShift compatibility: allow arbitrary UID to run with root group permissions
+RUN chgrp -R 0 \
+      /etc/apache2 \
+      /var/run/apache2 \
+      /var/lock/apache2 \
+      /var/log/apache2 \
+      /var/lib/apache2 \
+      /var/lib/qgis \
+      /.cache \
+      /etc/cache \
+      /var/cache/fontconfig \
+ && chmod -R g=u \
+      /etc/apache2 \
+      /var/run/apache2 \
+      /var/lock/apache2 \
+      /var/log/apache2 \
+      /var/lib/apache2 \
+      /var/lib/qgis \
+      /.cache \
+      /etc/cache \
+      /var/cache/fontconfig
+
 # ENV variables that will be used to configure QGIS server FCGI
 # apache2 specific variables
 ENV APACHE_LOG_LEVEL=info


### PR DESCRIPTION
## Summary
- Added a dedicated compatibility step that applies `chgrp -R 0` and `chmod -R g=u` to Apache/QGIS/cache runtime paths.

## Why
- We want a single primary image definition that works in both standard container environments and OpenShift.
- OpenShift commonly runs containers with arbitrary UIDs; the group-based permission pattern (`root` group + `g=u`) ensures required runtime paths stay writable.

## Impact
- Non-OpenShift behavior remains functionally the same, while OpenShift compatibility is now built into the main image build path.
- No runtime user change was introduced (`USER $UID` remains in place).
