### PR TITLE
fix(entrypoint.sh): add sed escape for FCGID_EXTRA_ENV var

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,8 @@ ORIG_IFS=$IFS
 IFS=","
 for extra_env in $FCGID_EXTRA_ENV; do
   if [ ! -z ${!extra_env} ]; then
-    sed -i "s|@FCGID_EXTRA_ENV@|FcgidInitialEnv ${extra_env} ${!extra_env}\n@FCGID_EXTRA_ENV@|" /tmp/qgis-server.conf.template
+    repl=$(sed -e 's/[&\\/]/\\&/g; s/$/\\/' -e '$s/\\$//' <<<"${!extra_env}")
+    sed -i "s|@FCGID_EXTRA_ENV@|FcgidInitialEnv ${extra_env} ${repl}\n@FCGID_EXTRA_ENV@|" /tmp/qgis-server.conf.template
   fi
 done
 IFS=$ORIG_IFS


### PR DESCRIPTION
When a var referenced by FCGID_EXTRA_ENV contains a '&' or '/' it is interpreted by sed. To avoid that it must be escaped (see https://unix.stackexchange.com/a/255869).