### PR TITLE
feat: add support for Apache PassEnv directive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,6 +149,8 @@ ENV QGIS_AUTH_DB_URI=""
 ENV QGIS_AUTH_PASSWORD_FILE=""
 ENV FCGID_EXTRA_ENV=""
 
+ENV PASS_EXTRA_ENV=""
+
 # Add apache config for QGIS server
 ADD qgis3-server.conf.template /etc/apache2/templates/qgis-server.conf.template
 

--- a/README.md
+++ b/README.md
@@ -80,11 +80,20 @@ Additional ENV-vars
 -------------------
 
 You can pass arbitrary environment variables to FCGI by setting `FCGID_EXTRA_ENV` to a comma-separated list of additional variables,
-and then setting the variables itself. This is useful for instance for qgis server plugins.
+and then setting the variables itself. This is useful for instance for qgis server plugins. This variables will be used at FCGI initialization time.
 
 Example:
 
       FCGID_EXTRA_ENV=FOO,BAR
+      FOO=foo_val
+      BAR=bar_val
+
+You can also pass arbitrary environment variables to FCGI by setting `PASS_EXTRA_ENV` to a comma-separated list of additional variables,
+and then setting the variables itself. This is useful when running providers with runtime loading environnment (as GDAL driver 'Microsoft Azure blob containers').
+
+Example:
+
+      PASS_EXTRA_ENV=FOO,BAR
       FOO=foo_val
       BAR=bar_val
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,8 +26,15 @@ for extra_env in $FCGID_EXTRA_ENV; do
     sed -i "s|@FCGID_EXTRA_ENV@|FcgidInitialEnv ${extra_env} ${repl}\n@FCGID_EXTRA_ENV@|" /tmp/qgis-server.conf.template
   fi
 done
+for extra_env in $PASS_EXTRA_ENV; do
+  if [ ! -z ${!extra_env} ]; then
+    sed -i "s|@PASS_EXTRA_ENV@|PassEnv ${extra_env}\n@PASS_EXTRA_ENV@|" /tmp/qgis-server.conf.template
+  fi
+done
 IFS=$ORIG_IFS
+
 sed -i "s|@FCGID_EXTRA_ENV@||" /tmp/qgis-server.conf.template
+sed -i "s|@PASS_EXTRA_ENV@||" /tmp/qgis-server.conf.template
 
 # Substitute predefined variables from ENV
 envsubst < /tmp/qgis-server.conf.template > /etc/apache2/sites-enabled/qgis-server.conf

--- a/qgis3-server.conf.template
+++ b/qgis3-server.conf.template
@@ -88,6 +88,8 @@ ServerName 127.0.0.1
     FcgidInitialEnv QGIS_SERVER_WMTS_SERVICE_URL ${QGIS_SERVER_WMTS_SERVICE_URL}
     @FCGID_EXTRA_ENV@
 
+    @PASS_EXTRA_ENV@
+
     SetEnv PGSERVICEFILE /etc/postgresql-common/pg_service.conf
     SetEnv PGPASSFILE /etc/postgresql-common/pgpass.conf
 


### PR DESCRIPTION
This commit add a new PASS_EXTRA_ENV env similar to FGCI_EXTRA_ENV to declare env var to use with PassEnv.

In some cases environment variables are not available in the FCGI process when defined with FcgidInitialEnv. For example, after the process creation, a new FCGI call can create subprocesses and env var are not propagated. To do so, PassEnv directive must be used.

Co-Authored-By: benoitblanc

Fix #16 by replacing ',' in sed expression by 2 sed calls. 